### PR TITLE
Fixing a dependency if $bacula::working_directory = /var/lib/bacula

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -220,10 +220,13 @@ class bacula (
     owner   => $bacula::process_owner,
     group   => $bacula::process_group,
     require => User[$bacula::process_owner],
-  } ->
-  file { '/var/lib/bacula':
-    ensure => link,
-    target => $bacula::working_directory,
+  }
+  if $bacula::working_directory != '/var/lib/bacula' {
+    file { '/var/lib/bacula':
+      ensure  => link,
+      target  => $bacula::working_directory,
+      require => File[$bacula::working_directory],
+    }
   }
 
   file { 'bacula.dir':


### PR DESCRIPTION
Duplicate declaration: File[/var/lib/bacula] is already declared in file /etc/puppet/modules/bacula/manifests/init.pp:223; cannot redeclare at /etc/puppet/modules/bacula/manifests/init.pp:227

The above error occurs if $bacula::working_directory = /var/lib/bacula
