### PR TITLE
Adding double-quotes around all storage resource names

### DIFF
--- a/manifests/director/job.pp
+++ b/manifests/director/job.pp
@@ -57,14 +57,6 @@ define bacula::director::job (
     default => $messages,
   }
 
-  $array_storages = is_array($storage) ? {
-    false     => $storage ? {
-      ''      => [],
-      default => [$storage],
-    },
-    default   => $storage,
-  }
-
   $manage_job_file_content = $template ? {
     ''      => undef,
     default => template($template),

--- a/spec/defines/bacula_director_job_spec.rb
+++ b/spec/defines/bacula_director_job_spec.rb
@@ -62,7 +62,7 @@ Job {
   Level = "Full"
   Type = restore
   FileSet = "standardLinuxFileSet"
-  Storage = restoreStorage
+  Storage = "restoreStorage"
   Pool = "FullPool"
   Priority = 1
   Messages = "standard"

--- a/spec/defines/bacula_director_pool_spec.rb
+++ b/spec/defines/bacula_director_pool_spec.rb
@@ -75,7 +75,7 @@ Pool {
   Volume Use Duration = 2 minutes
   VolumeRetention = 2 month
   LabelFormat = "Volume-Number-"
-  Storage = SomeStorage
+  Storage = "SomeStorage"
 }
 '
     end

--- a/templates/director/job.conf.erb
+++ b/templates/director/job.conf.erb
@@ -24,7 +24,7 @@ Job {
   FileSet = "<%= @fileset %>"
 <% end -%>
 <% if @storage != '' -%>
-  Storage = <%= @array_storages * ',' %>
+  Storage = "<%= @storage %>"
 <% end -%>
 <% if @pool != '' -%>
   Pool = "<%= @pool %>"

--- a/templates/director/pool.conf.erb
+++ b/templates/director/pool.conf.erb
@@ -31,6 +31,6 @@ Pool {
   LabelFormat = "<%= @label_format %>"
 <% end -%>
 <% if @storage != '' -%>
-  Storage = <%= @storage %>
+  Storage = "<%= @storage %>"
 <% end -%>
 }


### PR DESCRIPTION
Fixes what was discussed in #19.
