### PR TITLE
Add default value for $working_directory on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,8 @@ class bacula::params {
   }
   $heartbeat_interval = '1 minute'
   $working_directory  = $::operatingsystem ? {
-    default => '/var/spool/bacula'
+    /(?i:Debian|Ubuntu|Mint)/ => '/var/lib/bacula',
+    default                   => '/var/spool/bacula',
   }
 
   $password_salt = ''


### PR DESCRIPTION
The default value '/var/lib/bacula' for baculas working directory is
added for Debian, Ubuntu and Mint distributions.

Fixes https://github.com/netmanagers/puppet-bacula/issues/30
