### PR TITLE
Fix default database password for catalog

### DIFF
--- a/manifests/director/catalog.pp
+++ b/manifests/director/catalog.pp
@@ -21,7 +21,7 @@ define bacula::director::catalog (
   }
 
   $real_password = $db_password ? {
-    ''      => $bacula::real_default_password,
+    ''      => $bacula::database_password,
     default => $db_password,
   }
 


### PR DESCRIPTION
Default database password for the catalog should be the predefined database password, not the bacula director, client, etc. password.
