### PR TITLE
Fix: allow creation of multiple file devices

### DIFF
--- a/manifests/storage/device.pp
+++ b/manifests/storage/device.pp
@@ -36,7 +36,7 @@ define bacula::storage::device (
   if  $device_type == 'File' and
       !defined(File[$real_archive_device]) {
     # Puppet lacks recursive dir creation, and we might use subdirs as storage
-    exec { 'mkdir_archive_dir':
+    exec { "mkdir_archive_dir ${real_archive_device}":
       path    => [ '/bin', '/usr/bin' ],
       command => "mkdir -p ${real_archive_device}",
       unless  => "test -d ${real_archive_device}",


### PR DESCRIPTION
All exec statements for the "mkdir" had the same title so declaring multiple devices was impossible.
